### PR TITLE
Navbar fixed

### DIFF
--- a/_includes/front/nav-header.html
+++ b/_includes/front/nav-header.html
@@ -18,7 +18,7 @@
                     <ul class="nav navbar-nav">
                         <li><a href="#rooms">MYSTERIES</a></li>
                         <li><a href="#faq">FAQ</a></li>
-                        <li><a href="#about-us">CONTACT US</a></li>
+                        <li><a href="#about-us">ABOUT US</a></li>
                     </ul>
                 </div>
         </div>

--- a/_includes/front/nav-header.html
+++ b/_includes/front/nav-header.html
@@ -16,9 +16,9 @@
         <div class="collapse navbar-collapse" id="nav-links">
                 <div class="navbar-right">
                     <ul class="nav navbar-nav">
-                        <li><a href>MYSTERIES</a></li>
+                        <li><a href="#rooms">MYSTERIES</a></li>
                         <li><a href="#faq">FAQ</a></li>
-                        <li><a href>CONTACT US</a></li>
+                        <li><a href="#about-us">CONTACT US</a></li>
                     </ul>
                 </div>
         </div>

--- a/_sass/_mysteryManila.scss
+++ b/_sass/_mysteryManila.scss
@@ -476,6 +476,7 @@ div#rooms {
   }
   #faq {
     line-height: 2.5;
+    padding-top: 32px;
     h2 {
       text-align: center;
     }

--- a/js/home.js
+++ b/js/home.js
@@ -46,7 +46,7 @@ mm.autoHideNavbar = function(){
             var lastMouseMove = new Date().getTime();
             var t = setTimeout(function () {
                 if (new Date().getTime() - lastMouseMove > 2000 &&
-                    ($(document).scrollTop() >= $('#about').offset().top) && !$('.navbar').is(':hover')) {
+                    ($(document).scrollTop() >= $('#teaser').offset().top) && !$('.navbar').is(':hover')) {
                     $('.navbar').removeClass('navbar-visible').addClass('navbar-hidden');
                 }
             }, 2000)
@@ -63,8 +63,9 @@ mm.initNavbar = function(){
     $(document).on('click', '.navbar-nav li a', function(e){
         e.preventDefault();
         $link = $(e.target);
-        $('html, body').animate({scrollTop: $($link.attr('href')).offset().top - 96}, 'easeInOutExpo');
+        $('html, body').animate({scrollTop: $($link.attr('href')).offset().top}, 'easeInOutExpo');
     });
+    mm.autoHideNavbar();
 };
 
 mm.sidebar = mm.sidebar || {};


### PR DESCRIPTION
- reverted to auto-hide
- links point to proper targets
- renamed 'Contact Us' to 'About Us'
  see commits. fixes #56 
